### PR TITLE
Replace IPv6 localhost “::1” with 127.0.0.1

### DIFF
--- a/PayfortIntegration.php
+++ b/PayfortIntegration.php
@@ -352,7 +352,7 @@ class PayfortIntegration
             'access_code'         => $this->accessCode,
             'command'             => $this->command,
             'merchant_identifier' => $this->merchantIdentifier,
-            'customer_ip'         => $_SERVER['REMOTE_ADDR'],
+            'customer_ip'         => $_SERVER['REMOTE_ADDR'] === '::1'? '127.0.0.1' : $_SERVER['REMOTE_ADDR'],
             'amount'              => $this->convertFortAmount($this->amount, $this->currency),
             'currency'            => strtoupper($this->currency),
             'customer_email'      => $this->customerEmail,


### PR DESCRIPTION
Hello Team,

I had an issue with XAMPP on Mac OS where XAMPP is returning IPv6 localhost IP (::1) which is not accepted in the FORT.

I've added a small check to replace it with 127.0.0.1

I'm not sure if inline conditions is within the style guide. If it's not I'll be happy to change it.
