### PR TITLE
php7 issue fix

### DIFF
--- a/PayfortIntegration.php
+++ b/PayfortIntegration.php
@@ -528,7 +528,7 @@ class PayfortIntegration
 
     public function generateMerchantReference()
     {
-        return rand(0, 9999999999);
+        return rand(0, getrandmax());
     }
     
     /**


### PR DESCRIPTION
fixing issue with PHP version 7

PHP Warning:  rand() expects parameter 2 to be integer, float given