### PR TITLE
Generate URLs with correct http/https scheme

### DIFF
--- a/PayfortIntegration.php
+++ b/PayfortIntegration.php
@@ -522,7 +522,8 @@ class PayfortIntegration
 
     public function getUrl($path)
     {
-        $url = 'http://' . $_SERVER['HTTP_HOST'] . $this->projectUrlPath .'/'. $path;
+        $scheme = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
+        $url = $scheme . $_SERVER['HTTP_HOST'] . $this->projectUrlPath .'/'. $path;
         return $url;
     }
 


### PR DESCRIPTION
Merchants using the PHP SDK would run into issues when creating requests as the code would always generate return URLs that use HTTP even if the website is using HTTPS. This leads to security warnings in Firefox and leads to any content in iframes to be blocked by browsers. (See: [Mixed active content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content#Mixed_active_content))

